### PR TITLE
Update AmmoMagazines - LYNX.sbc

### DIFF
--- a/Data/AmmoMagazines - LYNX.sbc
+++ b/Data/AmmoMagazines - LYNX.sbc
@@ -34,7 +34,7 @@
         <Y>0.2</Y>
         <Z>0.2</Z>
       </Size>
-      <Mass>680</Mass>
+      <Mass>30</Mass>
       <Volume>100</Volume>
       <Model>Models\Items\Components\autocannon185.mwm</Model>
       <Capacity>400</Capacity>


### PR DESCRIPTION
the mass of the ammo for avengers was hilariously high so it weighed a TON