### PR TITLE
Update twinrail.cs

### DIFF
--- a/Data/Scripts/WeaponThread/twinrail.cs
+++ b/Data/Scripts/WeaponThread/twinrail.cs
@@ -89,12 +89,12 @@ namespace WeaponThread {
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 30, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 15, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 1000, //heat generated per shot
-                    MaxHeat = 10000, //max heat before weapon enters cooldown (70% of max heat)
+                    MaxHeat = 15000, //max heat before weapon enters cooldown (70% of max heat)
                     Cooldown = .50f, //percent of max heat to be under to start firing again after overheat accepts .2-.95
-                    HeatSinkRate = 300, //amount of heat lost per second
+                    HeatSinkRate = 500, //amount of heat lost per second
                     DegradeRof = false, // progressively lower rate of fire after 80% heat threshold (80% of max heat)
                     ShotsInBurst = 0,
                     DelayAfterBurst = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).


### PR DESCRIPTION
currently twin rails are worse than the single rails so this buff should make them able to fire for a longer period of time but still do same damage per shot